### PR TITLE
Substract a maxValue to prevent overflow of e(y)

### DIFF
--- a/py/DataLoader.py
+++ b/py/DataLoader.py
@@ -13,7 +13,8 @@ def softmax(mat):
 	res=np.zeros(mat.shape)
 	for t in range(maxT):
 		y=mat[t,:]
-		e=np.exp(y)
+		maxValue = np.max(y)
+		e=np.exp(y - maxValue)
 		s=np.sum(e)
 		res[t,:]=e/s
 


### PR DESCRIPTION
Python prototype, version is 3.6
It's not a logical problem, just a trick to prevent overflow by np.exp(y) when y is big.
Substract a maxValue is a common operation, which can also be found in [TensorFlow](https://github.com/tensorflow/tensorflow/blob/722510d6964715cba51c86e29cde8be396d1bf72/tensorflow/python/keras/activations_test.py):
```Python
def _ref_softmax(values):
  m = np.max(values)
  e = np.exp(values - m)
return e / np.sum(e)
```