### PR TITLE
Fix installation on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ out.csv
 *.opendb
 *.suo
 *.swp
+*.pyd
 **/.vs
 **/Release
 **/Debug

--- a/cpp/pybind/pybind11/numpy.h
+++ b/cpp/pybind/pybind11/numpy.h
@@ -27,6 +27,10 @@
 #if defined(_MSC_VER)
 #  pragma warning(push)
 #  pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
+
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+
 #endif
 
 /* This will be true on all flat address space platforms and allows us to reduce the


### PR DESCRIPTION
This PR fixes `pip install -e .` on Windows 10 with MSVS 2022 installed.